### PR TITLE
Implement Runner interface

### DIFF
--- a/buildpack/dependencies.go
+++ b/buildpack/dependencies.go
@@ -71,3 +71,13 @@ func (d Dependencies) Has(id string) bool {
 
 	return false
 }
+
+func (d Dependencies) String() string {
+	var result string
+
+	for _, c := range d {
+		result = fmt.Sprintf("%s\nID: %s Version: %s Stacks: %s", result, c.ID, c.Version.Version, c.Stacks)
+	}
+
+	return result
+}

--- a/buildpack/dependencies_test.go
+++ b/buildpack/dependencies_test.go
@@ -163,10 +163,22 @@ func TestDependencies(t *testing.T) {
 					URI:     "test-uri",
 					SHA256:  "test-sha256",
 					Stacks:  buildpack.Stacks{"test-stack-1", "test-stack-3"}},
+				buildpack.Dependency{
+					ID:      "test-id-2",
+					Name:    "test-name",
+					Version: internal.NewTestVersion(t, "1.1"),
+					URI:     "test-uri",
+					SHA256:  "test-sha256",
+					Stacks:  buildpack.Stacks{"test-stack-1", "test-stack-3"}},
 			}
 
 			_, err := d.Best("test-id-2", "1.0", "test-stack-1")
 			g.Expect(err).To(HaveOccurred())
+			expectedError := `no valid dependencies for test-id-2, 1.0, and test-stack-1 in 
+ID: test-id Version: 1.0.0 Stacks: [test-stack-1 test-stack-2]
+ID: test-id Version: 1.0.0 Stacks: [test-stack-1 test-stack-3]
+ID: test-id-2 Version: 1.1.0 Stacks: [test-stack-1 test-stack-3]`
+			g.Expect(err).To(MatchError(expectedError))
 		})
 
 		it("substitutes all wildcard for unspecified version constraint", func() {

--- a/helper/command_runner.go
+++ b/helper/command_runner.go
@@ -1,0 +1,17 @@
+package helper
+
+import (
+"os"
+"os/exec"
+)
+
+type CommandRunner struct {
+}
+
+func (r CommandRunner) Run(bin, dir string, args ...string) error {
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -26,16 +26,31 @@ import (
 
 const indent = "      "
 
-var eyeCatcher string
+var (
+	error     string
+	firstLine string
+	warning   string
+)
 
 func init() {
 	color.NoColor = false
-	eyeCatcher = color.New(color.FgRed, color.Bold).Sprint("----->")
+	error = color.New(color.FgRed, color.Bold).Sprint("----->")
+	firstLine = color.New(color.FgRed, color.Bold).Sprint("----->")
+	warning = color.New(color.FgYellow, color.Bold).Sprint("----->")
 }
 
 // Logger is an extension to libbuildpack.Logger to add additional functionality.
 type Logger struct {
 	logger.Logger
+}
+
+// Error prints the log message with the error eye catcher.
+func (l Logger) Error(format string, args ...interface{}) {
+	if !l.IsInfoEnabled() {
+		return
+	}
+
+	l.Info("%s %s", error, fmt.Sprintf(format, args...))
 }
 
 // FirstLine prints the log messages with the first line eye catcher.
@@ -44,16 +59,7 @@ func (l Logger) FirstLine(format string, args ...interface{}) {
 		return
 	}
 
-	l.Info("%s %s", eyeCatcher, fmt.Sprintf(format, args...))
-}
-
-// SubsequentLine prints log message with the subsequent line indent.
-func (l Logger) SubsequentLine(format string, args ...interface{}) {
-	if !l.IsInfoEnabled() {
-		return
-	}
-
-	l.Info("%s %s", indent, fmt.Sprintf(format, args...))
+	l.Info("%s %s", firstLine, fmt.Sprintf(format, args...))
 }
 
 // PrettyIdentity formats a standard pretty identity of a type.
@@ -79,4 +85,22 @@ func (l Logger) PrettyIdentity(v Identifiable) string {
 // String makes Logger satisfy the Stringer interface.
 func (l Logger) String() string {
 	return fmt.Sprintf("Logger{ Logger: %s }", l.Logger)
+}
+
+// SubsequentLine prints log message with the subsequent line indent.
+func (l Logger) SubsequentLine(format string, args ...interface{}) {
+	if !l.IsInfoEnabled() {
+		return
+	}
+
+	l.Info("%s %s", indent, fmt.Sprintf(format, args...))
+}
+
+// Warning prints the log message with the warning eye catcher.
+func (l Logger) Warning(format string, args ...interface{}) {
+	if !l.IsInfoEnabled() {
+		return
+	}
+
+	l.Info("%s %s", warning, fmt.Sprintf(format, args...))
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -43,6 +43,24 @@ func TestLogger(t *testing.T) {
 			g.Expect(info.String()).To(Equal(fmt.Sprintf("%s test message\n", color.New(color.FgRed, color.Bold).Sprint("----->"))))
 		})
 
+		it("writes eye catcher on warning", func() {
+			var info bytes.Buffer
+
+			logger := logger.Logger{Logger: bp.NewLogger(nil, &info)}
+			logger.Warning("test %s", "message")
+
+			g.Expect(info.String()).To(Equal(fmt.Sprintf("%s test message\n", color.New(color.FgYellow, color.Bold).Sprint("----->"))))
+		})
+
+		it("writes eye catcher on error", func() {
+			var info bytes.Buffer
+
+			logger := logger.Logger{Logger: bp.NewLogger(nil, &info)}
+			logger.Error("test %s", "message")
+
+			g.Expect(info.String()).To(Equal(fmt.Sprintf("%s test message\n", color.New(color.FgRed, color.Bold).Sprint("----->"))))
+		})
+
 		it("writes indent on second line", func() {
 			var info bytes.Buffer
 


### PR DESCRIPTION
We have a [runner interface](https://github.com/cloudfoundry/yarn-cnb/blob/7c7734121f8ebe59d198d724178190d7e39ee0db/yarn/yarn.go#L17) that comes in handy when we want to mock out calls that exec a shell command.

Each of our cnb buildpacks implements the runner interface in a utils class. See for example
- https://github.com/cloudfoundry/npm-cnb/blob/master/utils/utils.go
- https://github.com/cloudfoundry/yarn-cnb/blob/master/utils/utils.go

Would be great to reduce the replication of utils.go.