### PR TITLE
Update output for missing dependency

### DIFF
--- a/buildpack/dependencies.go
+++ b/buildpack/dependencies.go
@@ -50,7 +50,7 @@ func (d Dependencies) Best(id string, versionConstraint string, stack stack.Stac
 	}
 
 	if len(candidates) == 0 {
-		return Dependency{}, fmt.Errorf("no valid dependencies for %s, %s, and %s in %s", id, vc, stack, d)
+		return Dependency{}, fmt.Errorf("no valid dependencies for %s, %s, and %s in%s", id, vc, stack, d.missing())
 	}
 
 	sort.Slice(candidates, func(i int, j int) bool {
@@ -70,4 +70,14 @@ func (d Dependencies) Has(id string) bool {
 	}
 
 	return false
+}
+
+func (d Dependencies) missing() string {
+	var result string
+
+	for _, c := range d {
+		result = fmt.Sprintf("%s\nID: %s Version: %s Stacks: %s", result, c.ID, c.Version.Version, c.Stacks)
+	}
+
+	return result
 }

--- a/buildpack/dependencies_test.go
+++ b/buildpack/dependencies_test.go
@@ -163,10 +163,22 @@ func TestDependencies(t *testing.T) {
 					URI:     "test-uri",
 					SHA256:  "test-sha256",
 					Stacks:  buildpack.Stacks{"test-stack-1", "test-stack-3"}},
+				buildpack.Dependency{
+					ID:      "test-id-2",
+					Name:    "test-name",
+					Version: internal.NewTestVersion(t, "1.1"),
+					URI:     "test-uri",
+					SHA256:  "test-sha256",
+					Stacks:  buildpack.Stacks{"test-stack-1", "test-stack-3"}},
 			}
 
 			_, err := d.Best("test-id-2", "1.0", "test-stack-1")
 			g.Expect(err).To(HaveOccurred())
+			expectedError := `no valid dependencies for test-id-2, 1.0, and test-stack-1 in
+ID: test-id Version: 1.0.0 Stacks: [test-stack-1 test-stack-2]
+ID: test-id Version: 1.0.0 Stacks: [test-stack-1 test-stack-3]
+ID: test-id-2 Version: 1.1.0 Stacks: [test-stack-1 test-stack-3]`
+			g.Expect(err).To(MatchError(expectedError))
 		})
 
 		it("substitutes all wildcard for unspecified version constraint", func() {


### PR DESCRIPTION
We noticed the output for a missing dependency is hard to parse when a buildpack has a lot of dependencies:
```
2019-02-21T12:00:07.77-0500 [STG/0] OUT no valid dependencies for node, 9000.0.0, and org.cloudfoundry.stacks.cflinuxfs3 in [Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 6.15.1 }, URI: https://nodejs.org/dist/v6.15.1/node-v6.15.1-linux-x64.tar.gz, SHA256: aa8ef47382853d7124110203c3773515cff00737f1cd7bce98bd388603141c6d, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 6.15.1 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-6.15.1-linux-x64-cflinuxfs2-16abb1a8.tgz, SHA256: 16abb1a8bcef1bc6339a738b51f5f2a5e7d48f820da2cec3f4912504517f7490, Stacks: [org.cloudfoundry.stacks.cflinuxfs2], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 6.15.1 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-6.15.1-linux-x64-cflinuxfs3-c8da2b6c.tgz, SHA256: c8da2b6c146c4bf3c72b35a879be1a5e6764229702ddf3b0ca159ed74debd381, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 6.16.0 }, URI: https://nodejs.org/dist/v6.16.0/node-v6.16.0-linux-x64.tar.gz, SHA256: 7f26cd9a2845df23773755a428d61b74fd80d48a991e964d12e85ae90ced81a0, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 6.16.0 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-6.16.0-linux-x64-cflinuxfs2-fa3b7202.tgz, SHA256: fa3b72020ee4005fd0168bef41a765bbc382e4c4fdf65011f6b1c0b5b631c1ab, Stacks: [org.cloudfoundry.stacks.cflinuxfs2], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 6.16.0 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-6.16.0-linux-x64-cflinuxfs3-45f43c54.tgz, SHA256: 45f43c544683bf31921a0e47e7c6edccb6115c59171d723a345e585382d962d1, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 8.14.1 }, URI: https://nodejs.org/dist/v8.14.1/node-v8.14.1-linux-x64.tar.gz, SHA256: ae9b04e0ad806dc31242ca02b84a84ea67c978e41f60d94ffca010ed3fe32735, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 8.14.1 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-8.14.1-linux-x64-cflinuxfs2-ae41693a.tgz, SHA256: ae41693a9d26a1fa3f55fd4613292d4ada8d55da7f000b5cb94793d04b8dcc08, Stacks: [org.cloudfoundry.stacks.cflinuxfs2], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 8.14.1 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-8.14.1-linux-x64-cflinuxfs3-a4e189cb.tgz, SHA256: a4e189cbe5b8d8329ca8004b23f510e1b796bc22dbeea00d89f01fcd0612685c, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 8.15.0 }, URI: https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-x64.tar.gz, SHA256: dc004e5c0f39c6534232a73100c194bc1446f25e3a6a39b29e2000bb3d139d52, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 8.15.0 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-8.15.0-linux-x64-cflinuxfs2-1e19815b.tgz, SHA256: 1e19815bf98e0555a9f6cbdb6b3031611718a38cacf7704ffb904be5a7bb9e58, Stacks: [org.cloudfoundry.stacks.cflinuxfs2], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 8.15.0 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-8.15.0-linux-x64-cflinuxfs3-97413182.tgz, SHA256: 974131821556a7272c9025766ab6620e059068c5eb5418eb72abc6c397bac12d, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 9.11.1 }, URI: https://nodejs.org/dist/v9.11.1/node-v9.11.1-linux-x86.tar.gz, SHA256: c15307591aad4b65e984a3c25f39f5d102524190c1859a3fb7de166ac5e2641c, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 9.11.1 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-9.11.1-linux-x64-cflinuxfs2-a0086713.tgz, SHA256: a008671311b82aac5d30a0c1f40b55f80b79406da9f0f11fd1df5b4d7cfd882b, Stacks: [org.cloudfoundry.stacks.cflinuxfs2], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 9.11.1 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-9.11.1-linux-x64-cflinuxfs3-a7afe5ae.tgz, SHA256: a7afe5aea16738c92b443b0aced859de422447dfb6da8d23d8c95e78e238f3d6, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 9.11.2 }, URI: https://nodejs.org/dist/v9.11.2/node-v9.11.2-linux-x64.tar.gz, SHA256: 166cc28bd9c8217c533b2921edd5e980b14f1d670d828e9d40c1d5b37f51496d, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 9.11.2 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-9.11.2-linux-x64-cflinuxfs2-58d0bbd0.tgz, SHA256: 58d0bbd00dce33927281735870b490175f1135e7ac927cb2ac30edf744476474, Stacks: [org.cloudfoundry.stacks.cflinuxfs2], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 9.11.2 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-9.11.2-linux-x64-cflinuxfs3-86e844f9.tgz, SHA256: 86e844f98106131e3e2e05c54baa900ecc21294b73b78e2fc79ca39fe93b7b34, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 10.14.2 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-10.14.2-linux-x64-cflinuxfs2-331f06e2.tgz, SHA256: 331f06e2a5fdeeb0f681adce81bc07682bac0418c114f775d07cdabaa0808726, Stacks: [org.cloudfoundry.stacks.cflinuxfs2], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 10.15.0 }, URI: https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-x64.tar.gz, SHA256: f0b4ff9a74cbc0106bbf3ee7715f970101ac5b1bbe814404d7a0673d1da9f674, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 10.15.0 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-10.15.0-linux-x64-cflinuxfs2-d1a7fed0.tgz, SHA256: d1a7fed0e8d379dbd588f67cba937ab87021360e43d8960466f73ece91f6ea41, Stacks: [org.cloudfoundry.stacks.cflinuxfs2], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 10.15.0 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-10.15.0-linux-x64-cflinuxfs3-b811b474.tgz, SHA256: b811b474c46e37e3d903a4dd9815dc4f02c26e3aa3ae7d2c08e0b4ca299909a8, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 10.15.1 }, URI: https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-x64.tar.gz, SHA256: ca1dfa9790876409c8d9ecab7b4cdb93e3276cedfc64d56ef1a4ff1778a40214, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 10.15.1 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-10.15.1-linux-x64-cflinuxfs3-c18cef62.tgz, SHA256: c18cef62f2fdd97533595e48749f4a2d1b31b9b724b1907a0c69737906b1d177, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 11.8.0 }, URI: https://nodejs.org/dist/v11.8.0/node-v11.8.0-linux-x64.tar.gz, SHA256: 5787b70b35eb5c819be4475d3aedd332d68d01dc12651374a209961b7202a6bc, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 11.8.0 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-11.8.0-linux-x64-cflinuxfs3-6278dd3f.tgz, SHA256: 6278dd3f3e631e1ebdbeb3bede1df09f8fbd59fe86c5dd3e43fd5364196182ad, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 11.9.0 }, URI: https://nodejs.org/dist/v11.9.0/node-v11.9.0-linux-x64.tar.gz, SHA256: 0e872c288724e7de72eaa89d1fbc29979a60cdc8c4c0bc1ea65339328bbaaf4c, Stacks: [io.buildpacks.stacks.bionic], Licenses: [] } Dependency{ ID: node, Name: NodeJS, Version: Version{ Version: 11.9.0 }, URI: https://buildpacks.cloudfoundry.org/dependencies/node/node-11.9.0-linux-x64-cflinuxfs3-6214eecb.tgz, SHA256: 6214eecbe1a333179a017d9a19b537b514deb5e21175a8f41caf117e70bf897f, Stacks: [org.cloudfoundry.stacks.cflinuxfs3], Licenses: [] }]
```

Our attempt at making it look better looks like this:
```
2019-02-21T12:00:07.77-0500 [STG/0] OUT no valid dependencies for node, 9000.0.0, and org.cloudfoundry.stacks.cflinuxfs3 in
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 6.15.1 Stacks: [io.buildpacks.stacks.bionic]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 6.15.1 Stacks: [org.cloudfoundry.stacks.cflinuxfs2]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 6.15.1 Stacks: [org.cloudfoundry.stacks.cflinuxfs3]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 6.16.0 Stacks: [io.buildpacks.stacks.bionic]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 6.16.0 Stacks: [org.cloudfoundry.stacks.cflinuxfs2]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 6.16.0 Stacks: [org.cloudfoundry.stacks.cflinuxfs3]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 8.14.1 Stacks: [io.buildpacks.stacks.bionic]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 8.14.1 Stacks: [org.cloudfoundry.stacks.cflinuxfs2]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 8.14.1 Stacks: [org.cloudfoundry.stacks.cflinuxfs3]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 8.15.0 Stacks: [io.buildpacks.stacks.bionic]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 8.15.0 Stacks: [org.cloudfoundry.stacks.cflinuxfs2]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 8.15.0 Stacks: [org.cloudfoundry.stacks.cflinuxfs3]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 9.11.1 Stacks: [io.buildpacks.stacks.bionic]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 9.11.1 Stacks: [org.cloudfoundry.stacks.cflinuxfs2]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 9.11.1 Stacks: [org.cloudfoundry.stacks.cflinuxfs3]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 9.11.2 Stacks: [io.buildpacks.stacks.bionic]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 9.11.2 Stacks: [org.cloudfoundry.stacks.cflinuxfs2]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 9.11.2 Stacks: [org.cloudfoundry.stacks.cflinuxfs3]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 10.14.2 Stacks: [org.cloudfoundry.stacks.cflinuxfs2]
2019-02-21T12:00:07.77-0500 [STG/0] OUT ID: node Version: 10.15.0 Stacks: [io.buildpacks.stacks.bionic]
...
```

Our v2 buildpacks just wrote the available versions based on the dependency name and stack:
```
Unable to install node: no match found for 1.1.1 in [1.2.1, 2.1.1, 3.1.1]
```

So we could do that too to simplify it. But show all of the dependencies in the buildpack.toml may make sense.