### PR TITLE
Add default_versions property to buildpack metadata

### DIFF
--- a/buildpack/buildpack.go
+++ b/buildpack/buildpack.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	cacheRoot           = "dependency-cache"
-	DefaultDependencies = "default_dependencies"
-	DefaultVersions     = "default_versions"
+	cacheRoot            = "dependency-cache"
+	DependenciesMetadata = "dependencies"
+	DefaultVersions      = "default_versions"
 )
 
 // Buildpack is an extension to libbuildpack.Buildpack that adds additional opinionated behaviors.
@@ -42,7 +42,7 @@ type Buildpack struct {
 
 // Dependencies returns the collection of dependencies extracted from the generic buildpack metadata.
 func (b Buildpack) Dependencies() (Dependencies, error) {
-	deps, ok := b.Metadata[DefaultDependencies].([]map[string]interface{})
+	deps, ok := b.Metadata[DependenciesMetadata].([]map[string]interface{})
 	if !ok {
 		return Dependencies{}, nil
 	}

--- a/buildpack/buildpack.go
+++ b/buildpack/buildpack.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	cacheRoot            = "dependency-cache"
-	DEPENDENCIES         = "dependencies"
-	DEFAULT_DEPENDENCIES = "default_dependencies"
+	cacheRoot           = "dependency-cache"
+	DefaultDependencies = "default_dependencies"
+	DefaultVersions     = "default_versions"
 )
 
 // Buildpack is an extension to libbuildpack.Buildpack that adds additional opinionated behaviors.
@@ -42,7 +42,7 @@ type Buildpack struct {
 
 // Dependencies returns the collection of dependencies extracted from the generic buildpack metadata.
 func (b Buildpack) Dependencies() (Dependencies, error) {
-	deps, ok := b.Metadata[DEPENDENCIES].([]map[string]interface{})
+	deps, ok := b.Metadata[DefaultDependencies].([]map[string]interface{})
 	if !ok {
 		return Dependencies{}, nil
 	}
@@ -61,13 +61,18 @@ func (b Buildpack) Dependencies() (Dependencies, error) {
 	return dependencies, nil
 }
 
-func (b Buildpack) DefaultVersion(id string) string {
-	defaults, ok := b.Metadata[DEFAULT_DEPENDENCIES].(map[string]interface{})
+func (b Buildpack) DefaultVersion(id string) (string, error) {
+	defaults, ok := b.Metadata[DefaultVersions].(map[string]interface{})
 	if !ok {
-		return ""
+		return "", nil
 	}
 
-	return defaults[id].(string)
+	version, ok := defaults[id].(string)
+	if !ok {
+		return "", fmt.Errorf("%s does not map to a string in %s map", id, DefaultVersions)
+	}
+
+	return version, nil
 }
 
 // Identity make Buildpack satisfy the Identifiable interface.

--- a/buildpack/buildpack.go
+++ b/buildpack/buildpack.go
@@ -18,14 +18,17 @@ package buildpack
 
 import (
 	"fmt"
-	"path/filepath"
-
 	"github.com/buildpack/libbuildpack/buildpack"
 	"github.com/cloudfoundry/libcfbuildpack/logger"
 	"github.com/mitchellh/mapstructure"
+	"path/filepath"
 )
 
-const cacheRoot = "dependency-cache"
+const (
+	cacheRoot            = "dependency-cache"
+	DEPENDENCIES         = "dependencies"
+	DEFAULT_DEPENDENCIES = "default_dependencies"
+)
 
 // Buildpack is an extension to libbuildpack.Buildpack that adds additional opinionated behaviors.
 type Buildpack struct {
@@ -39,7 +42,7 @@ type Buildpack struct {
 
 // Dependencies returns the collection of dependencies extracted from the generic buildpack metadata.
 func (b Buildpack) Dependencies() (Dependencies, error) {
-	deps, ok := b.Metadata["dependencies"].([]map[string]interface{})
+	deps, ok := b.Metadata[DEPENDENCIES].([]map[string]interface{})
 	if !ok {
 		return Dependencies{}, nil
 	}
@@ -56,6 +59,15 @@ func (b Buildpack) Dependencies() (Dependencies, error) {
 
 	b.logger.Debug("Dependencies: %s", dependencies)
 	return dependencies, nil
+}
+
+func (b Buildpack) DefaultVersion(id string) string {
+	defaults, ok := b.Metadata[DEFAULT_DEPENDENCIES].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	return defaults[id].(string)
 }
 
 // Identity make Buildpack satisfy the Identifiable interface.

--- a/buildpack/buildpack_test.go
+++ b/buildpack/buildpack_test.go
@@ -35,7 +35,7 @@ func TestBuildpack(t *testing.T) {
 		it("returns dependencies", func() {
 			b := bp.Buildpack{
 				Metadata: bp.Metadata{
-					"dependencies": []map[string]interface{}{
+					buildpack.DEPENDENCIES: []map[string]interface{}{
 						{
 							"id":      "test-id-1",
 							"name":    "test-name-1",
@@ -139,6 +139,22 @@ func TestBuildpack(t *testing.T) {
 
 			_, ok := buildpack.Buildpack{Buildpack: b}.PrePackage()
 			g.Expect(ok).To(BeFalse())
+		})
+
+		it("returns a default dependency if it exists", func() {
+			id := "test-id-1"
+			version := "1.0"
+
+			b := bp.Buildpack{
+				Metadata: bp.Metadata{
+					buildpack.DEFAULT_DEPENDENCIES: map[string]interface{}{
+						id: version,
+					},
+				},
+			}
+
+			g.Expect(buildpack.Buildpack{Buildpack: b}.DefaultVersion(id)).To(Equal(version))
+			g.Expect(buildpack.Buildpack{}.DefaultVersion("invalid-id")).To(Equal(""))
 		})
 
 	}, spec.Report(report.Terminal{}))

--- a/buildpack/buildpack_test.go
+++ b/buildpack/buildpack_test.go
@@ -37,7 +37,7 @@ func TestBuildpack(t *testing.T) {
 		it("returns dependencies", func() {
 			b := bp.Buildpack{
 				Metadata: bp.Metadata{
-					buildpack.DefaultDependencies: []map[string]interface{}{
+					buildpack.DependenciesMetadata: []map[string]interface{}{
 						{
 							"id":      "test-id-1",
 							"name":    "test-name-1",

--- a/buildpack/buildpack_test.go
+++ b/buildpack/buildpack_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/sclevine/spec/report"
 )
 
+
+
 func TestBuildpack(t *testing.T) {
 	spec.Run(t, "Buildpack", func(t *testing.T, _ spec.G, it spec.S) {
 
@@ -35,7 +37,7 @@ func TestBuildpack(t *testing.T) {
 		it("returns dependencies", func() {
 			b := bp.Buildpack{
 				Metadata: bp.Metadata{
-					buildpack.DEPENDENCIES: []map[string]interface{}{
+					buildpack.DefaultDependencies: []map[string]interface{}{
 						{
 							"id":      "test-id-1",
 							"name":    "test-name-1",
@@ -147,14 +149,49 @@ func TestBuildpack(t *testing.T) {
 
 			b := bp.Buildpack{
 				Metadata: bp.Metadata{
-					buildpack.DEFAULT_DEPENDENCIES: map[string]interface{}{
+					buildpack.DefaultVersions: map[string]interface{}{
 						id: version,
 					},
 				},
 			}
 
-			g.Expect(buildpack.Buildpack{Buildpack: b}.DefaultVersion(id)).To(Equal(version))
-			g.Expect(buildpack.Buildpack{}.DefaultVersion("invalid-id")).To(Equal(""))
+			ver, err := buildpack.Buildpack{Buildpack: b}.DefaultVersion(id)
+			g.Expect(ver).To(Equal(version))
+			g.Expect(err).ToNot(HaveOccurred())
+
+			ver, err = buildpack.Buildpack{}.DefaultVersion("invalid-id")
+			g.Expect(ver).To(Equal(""))
+			g.Expect(err).ToNot(HaveOccurred())
+		})
+
+		it("returns empty string if DefaultVersions has incorrect structure", func() {
+			id := "test-id-1"
+
+			b := bp.Buildpack{
+				Metadata: bp.Metadata{
+					buildpack.DefaultVersions: "foo",
+				},
+			}
+
+			ver, err := buildpack.Buildpack{Buildpack: b}.DefaultVersion(id)
+			g.Expect(ver).To(Equal(""))
+			g.Expect(err).ToNot(HaveOccurred())
+		})
+
+		it("returns an error if the type of values that DefaultVersions maps to are not strings", func() {
+			id := "test-id-1"
+
+			b := bp.Buildpack{
+				Metadata: bp.Metadata{
+					buildpack.DefaultVersions: map[string]interface{}{
+						id: 1,
+					},
+				},
+			}
+
+			ver, err := buildpack.Buildpack{Buildpack: b}.DefaultVersion(id)
+			g.Expect(ver).To(Equal(""))
+			g.Expect(err).To(HaveOccurred())
 		})
 
 	}, spec.Report(report.Terminal{}))

--- a/layers/dependency_layer_test.go
+++ b/layers/dependency_layer_test.go
@@ -72,7 +72,7 @@ URI = "%s"`, dependency.ID, dependency.Version.Original(), dependency.SHA256, de
 
 			contributed := false
 			g.Expect(layer.Contribute(func(artifact string, layer layers.DependencyLayer) error {
-				contributed = true;
+				contributed = true
 				return nil
 			})).To(Succeed())
 
@@ -88,7 +88,7 @@ URI = "%s"`, dependency.ID, dependency.Version.Original(), dependency.SHA256, de
 
 			contributed := false
 			g.Expect(layer.Contribute(func(artifact string, layer layers.DependencyLayer) error {
-				contributed = true;
+				contributed = true
 				return nil
 			})).To(Succeed())
 

--- a/test/have_layer_version.go
+++ b/test/have_layer_version.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/BurntSushi/toml"
+	"github.com/onsi/gomega/types"
+)
+
+// HaveLayerVersion tests that a layer has a specific version.
+func HaveLayerVersion(version string) types.GomegaMatcher {
+	return &haveLayerVersion{
+		version: version,
+	}
+}
+
+type haveLayerVersion struct {
+	version string
+}
+
+func (m *haveLayerVersion) Match(actual interface{}) (bool, error) {
+	path, err := m.path(actual)
+	if err != nil {
+		return false, err
+	}
+
+	layer := struct {
+		Metadata struct {
+			Version string `toml:"version"`
+		} `toml:"metadata"`
+	}{}
+
+	if _, err := toml.DecodeFile(path, &layer); err != nil {
+		return false, fmt.Errorf("failed to decode file: %s", err.Error())
+	}
+
+	if layer.Metadata.Version != m.version {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (m *haveLayerVersion) FailureMessage(actual interface{}) string {
+	return fmt.Sprintf("Expected\n\t%#v\nto have layer metadata\n\tversion: %s",
+		actual, m.version)
+}
+
+func (m *haveLayerVersion) NegatedFailureMessage(actual interface{}) string {
+	return fmt.Sprintf("Expected\n\t%#v\nnot to have layer metadata\n\tversion: %s",
+		actual, m.version)
+}
+
+func (m *haveLayerVersion) path(actual interface{}) (string, error) {
+	v := reflect.ValueOf(actual).FieldByName("Metadata")
+	if v == (reflect.Value{}) {
+		return "", fmt.Errorf("HaveLayerVersion matcher expects a layer")
+	}
+
+	return v.Interface().(string), nil
+}

--- a/test/test_build_factory.go
+++ b/test/test_build_factory.go
@@ -80,19 +80,19 @@ func (f *BuildFactory) AddDependencyWithVersion(id string, version string, fixtu
 }
 
 // AddDefaultDependendency adds a default dependency to the buildpack metadata
-func (f *BuildFactory) AddDefaultDependency(id, version string) {
+func (f *BuildFactory) SetDefaultDependency(id, version string) {
 	f.t.Helper()
 
 	if f.Build.Buildpack.Metadata == nil {
 		f.Build.Buildpack.Metadata = make(buildpack.Metadata)
 	}
 
-	if _, ok := f.Build.Buildpack.Metadata[buildpack.DefaultDependencies]; !ok {
-		f.Build.Buildpack.Metadata[buildpack.DefaultDependencies] = map[string]interface{}{}
+	if _, ok := f.Build.Buildpack.Metadata[buildpack.DefaultVersions]; !ok {
+		f.Build.Buildpack.Metadata[buildpack.DefaultVersions] = map[string]interface{}{}
 	}
 
 	metadata := f.Build.Buildpack.Metadata
-	metadata[buildpack.DefaultDependencies].(map[string]interface{})[id] = version
+	metadata[buildpack.DefaultVersions].(map[string]interface{})[id] = version
 }
 
 // AddService adds an entry to the collection of services.

--- a/test/test_build_factory.go
+++ b/test/test_build_factory.go
@@ -79,6 +79,22 @@ func (f *BuildFactory) AddDependencyWithVersion(id string, version string, fixtu
 	f.addDependency(d)
 }
 
+// AddDefaultDependendency adds a default dependency to the buildpack metadata
+func (f *BuildFactory) AddDefaultDependency(id, version string) {
+	f.t.Helper()
+
+	if f.Build.Buildpack.Metadata == nil {
+		f.Build.Buildpack.Metadata = make(buildpack.Metadata)
+	}
+
+	if _, ok := f.Build.Buildpack.Metadata[buildpack.DEFAULT_DEPENDENCIES]; !ok {
+		f.Build.Buildpack.Metadata[buildpack.DEFAULT_DEPENDENCIES] = map[string]interface{}{}
+	}
+
+	metadata := f.Build.Buildpack.Metadata
+	metadata[buildpack.DEFAULT_DEPENDENCIES].(map[string]interface{})[id] = version
+}
+
 // AddService adds an entry to the collection of services.
 func (f *BuildFactory) AddService(name string, credentials services.Credentials, tags ...string) {
 	f.t.Helper()

--- a/test/test_build_factory.go
+++ b/test/test_build_factory.go
@@ -79,7 +79,7 @@ func (f *BuildFactory) AddDependencyWithVersion(id string, version string, fixtu
 	f.addDependency(d)
 }
 
-// AddDefaultDependendency adds a default dependency to the buildpack metadata
+// SetDefaultDependendency sets a default dependency to the buildpack metadata
 func (f *BuildFactory) SetDefaultDependency(id, version string) {
 	f.t.Helper()
 

--- a/test/test_build_factory.go
+++ b/test/test_build_factory.go
@@ -79,8 +79,8 @@ func (f *BuildFactory) AddDependencyWithVersion(id string, version string, fixtu
 	f.addDependency(d)
 }
 
-// SetDefaultDependendency sets a default dependency to the buildpack metadata
-func (f *BuildFactory) SetDefaultDependency(id, version string) {
+// SetDefaultVersion sets a default dependency to the buildpack metadata
+func (f *BuildFactory) SetDefaultVersion(id, version string) {
 	f.t.Helper()
 
 	if f.Build.Buildpack.Metadata == nil {
@@ -113,12 +113,12 @@ func (f *BuildFactory) addDependency(dependency buildpack.Dependency) {
 		f.Build.Buildpack.Metadata = make(buildpack.Metadata)
 	}
 
-	if _, ok := f.Build.Buildpack.Metadata["dependencies"]; !ok {
-		f.Build.Buildpack.Metadata["dependencies"] = make([]map[string]interface{}, 0)
+	if _, ok := f.Build.Buildpack.Metadata[buildpack.DependenciesMetadata]; !ok {
+		f.Build.Buildpack.Metadata[buildpack.DependenciesMetadata] = make([]map[string]interface{}, 0)
 	}
 
 	metadata := f.Build.Buildpack.Metadata
-	dependencies := metadata["dependencies"].([]map[string]interface{})
+	dependencies := metadata[buildpack.DependenciesMetadata].([]map[string]interface{})
 
 	var stacks []interface{}
 	for _, stack := range dependency.Stacks {
@@ -133,7 +133,7 @@ func (f *BuildFactory) addDependency(dependency buildpack.Dependency) {
 		})
 	}
 
-	metadata["dependencies"] = append(dependencies, map[string]interface{}{
+	metadata[buildpack.DependenciesMetadata] = append(dependencies, map[string]interface{}{
 		"id":       dependency.ID,
 		"name":     dependency.Name,
 		"version":  dependency.Version.Version.Original(),

--- a/test/test_build_factory.go
+++ b/test/test_build_factory.go
@@ -87,12 +87,12 @@ func (f *BuildFactory) AddDefaultDependency(id, version string) {
 		f.Build.Buildpack.Metadata = make(buildpack.Metadata)
 	}
 
-	if _, ok := f.Build.Buildpack.Metadata[buildpack.DEFAULT_DEPENDENCIES]; !ok {
-		f.Build.Buildpack.Metadata[buildpack.DEFAULT_DEPENDENCIES] = map[string]interface{}{}
+	if _, ok := f.Build.Buildpack.Metadata[buildpack.DefaultDependencies]; !ok {
+		f.Build.Buildpack.Metadata[buildpack.DefaultDependencies] = map[string]interface{}{}
 	}
 
 	metadata := f.Build.Buildpack.Metadata
-	metadata[buildpack.DEFAULT_DEPENDENCIES].(map[string]interface{})[id] = version
+	metadata[buildpack.DefaultDependencies].(map[string]interface{})[id] = version
 }
 
 // AddService adds an entry to the collection of services.

--- a/test/test_build_factory.go
+++ b/test/test_build_factory.go
@@ -79,7 +79,7 @@ func (f *BuildFactory) AddDependencyWithVersion(id string, version string, fixtu
 	f.addDependency(d)
 }
 
-// SetDefaultVersion sets a default dependency to the buildpack metadata
+// SetDefaultVersion sets a default dependency version in the buildpack metadata
 func (f *BuildFactory) SetDefaultVersion(id, version string) {
 	f.t.Helper()
 


### PR DESCRIPTION
Some buildpacks need default versions for dependencies to ensure forwards compatibility across buildpack versions. We added the idea of the `default_versions` property for `buildpack.toml` which is a map of dependency name to version string.

This change shouldn't affect any buildpacks without default versions. It will be a buildpack's responsibility to request a default version for a dependency if it can't find a version through user configuration.