### PR TITLE
Improve Runner interface and implementation

### DIFF
--- a/runner/command_runner.go
+++ b/runner/command_runner.go
@@ -23,20 +23,24 @@ import (
 
 // CommandRunner is an empty struct to hang the Run method on.
 type CommandRunner struct {
+	Dir string
+	Env []string
 }
 
 // Run makes CommandRunner satisfy the Runner interface.  This implementation delegates to exec.Command.
-func (r CommandRunner) Run(bin string, dir string, args ...string) error {
+func (r CommandRunner) Run(bin string, args ...string) error {
 	cmd := exec.Command(bin, args...)
-	cmd.Dir = dir
+	cmd.Dir = r.Dir
+	cmd.Env = r.Env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
 // RunWithOutput makes CommandRunner satisfy the Runner interface.  This implementation delegates to exec.Command.
-func (r CommandRunner) RunWithOutput(bin string, dir string, args ...string) ([]byte, error) {
+func (r CommandRunner) RunWithOutput(bin string, args ...string) ([]byte, error) {
 	cmd := exec.Command(bin, args...)
-	cmd.Dir = dir
+	cmd.Dir = r.Dir
+	cmd.Env = r.Env
 	return cmd.CombinedOutput()
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -19,8 +19,8 @@ package runner
 // Runner defines methods for executing commands.
 type Runner interface {
 	// Run configures a command and executes it, sending output to stdout and stderr.
-	Run(bin string, dir string, args ...string) error
+	Run(bin string, args ...string) error
 
 	// RunWithOutput configures a command and executes it, collecting output and returning it.
-	RunWithOutput(bin string, dir string, args ...string) ([]byte, error)
+	RunWithOutput(bin string, args ...string) ([]byte, error)
 }

--- a/test/runner.go
+++ b/test/runner.go
@@ -23,15 +23,15 @@ type Runner struct {
 }
 
 // Run makes Runner satisfy the helper.Runner interface.  This implementation collects the input.
-func (r *Runner) Run(bin string, dir string, args ...string) error {
-	r.Commands = append(r.Commands, Command{bin, dir, args})
+func (r *Runner) Run(bin string, args ...string) error {
+	r.Commands = append(r.Commands, Command{bin, args})
 	return nil
 }
 
 // RunWithOutput makes Runner satisfy the helper.Runner interface.  This implementation collects the input and return
 // configured output.
-func (r *Runner) RunWithOutput(bin string, dir string, args ...string) ([]byte, error) {
-	r.Commands = append(r.Commands, Command{bin, dir, args})
+func (r *Runner) RunWithOutput(bin string, args ...string) ([]byte, error) {
+	r.Commands = append(r.Commands, Command{bin, args})
 
 	output := r.Outputs[0]
 	r.Outputs = r.Outputs[1:]
@@ -41,6 +41,5 @@ func (r *Runner) RunWithOutput(bin string, dir string, args ...string) ([]byte, 
 
 type Command struct {
 	Bin  string
-	Dir  string
 	Args []string
 }


### PR DESCRIPTION
 - Having the directory in the middle of the command was weird.
 - Dir and Env now live on the CommandRunner struct. This lets your set
   the Dir and Env of the underlying Command while at the same time
   simplifying the interface.

Co-authored-by: Don Nguyen <dnguyen@pivotal.io>