### PR TITLE
Default versions specified with dashes

### DIFF
--- a/buildpack/buildpack.go
+++ b/buildpack/buildpack.go
@@ -28,7 +28,7 @@ import (
 const (
 	cacheRoot            = "dependency-cache"
 	DependenciesMetadata = "dependencies"
-	DefaultVersions      = "default_versions"
+	DefaultVersions      = "default-versions"
 )
 
 // Buildpack is an extension to libbuildpack.Buildpack that adds additional opinionated behaviors.

--- a/packager/cnbpackager/packager.go
+++ b/packager/cnbpackager/packager.go
@@ -327,7 +327,7 @@ func (p Packager) depsSummary(out *string) error {
 
 func (p Packager) defaultsSummary(out *string) {
 	bpMetadata := p.buildpack.Metadata
-	defaults, ok := bpMetadata["default_versions"].(map[string]interface{})
+	defaults, ok := bpMetadata[buildpack.DefaultVersions].(map[string]interface{})
 	if !ok {
 		return
 	}

--- a/packager/cnbpackager/testdata/summary-testdata/fake-cnb/buildpack.toml
+++ b/packager/cnbpackager/testdata/summary-testdata/fake-cnb/buildpack.toml
@@ -7,7 +7,7 @@ version = "0.0.1"
 include_files = ["bin/build","bin/detect","buildpack.toml"]
 pre_package = "./scripts/build.sh"
 
-[metadata.default_versions]
+[metadata.default-versions]
 dep1 = "4.5.x"
 
 [[metadata.dependencies]]


### PR DESCRIPTION
Per TOML conventions, `metadata.default_versions` should be `metadata.default-versions`

[#165888940](https://www.pivotaltracker.com/n/projects/1042066)

Co-authored-by: Tilly Taylor <mataylor@pivotal.io>