### PR TITLE
Switch *testing.T to interface TInterface

### DIFF
--- a/internal/new_test_version.go
+++ b/internal/new_test_version.go
@@ -17,13 +17,12 @@
 package internal
 
 import (
-	"testing"
-
 	"github.com/Masterminds/semver"
 	"github.com/cloudfoundry/libcfbuildpack/buildpack"
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 )
 
-func NewTestVersion(t *testing.T, version string) buildpack.Version {
+func NewTestVersion(t test_helper.TInterface, version string) buildpack.Version {
 	t.Helper()
 
 	v, err := semver.NewVersion(version)

--- a/internal/protect_env.go
+++ b/internal/protect_env.go
@@ -17,15 +17,15 @@
 package internal
 
 import (
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"os"
-	"testing"
 )
 
 // ProtectEnv protects a collection of environment variables.  Returns a function for use with defer in order to reset
 // the previous values.
 //
 // defer ProtectEnv(t, "alpha")()
-func ProtectEnv(t *testing.T, keys ...string) func() {
+func ProtectEnv(t test_helper.TInterface, keys ...string) func() {
 	t.Helper()
 
 	type state struct {

--- a/internal/replace_args.go
+++ b/internal/replace_args.go
@@ -17,15 +17,15 @@
 package internal
 
 import (
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"os"
-	"testing"
 )
 
 // ReplaceArgs replaces the current command line arguments (os.Args) with a new collection of values.  Returns a
 // function suitable for use with defer in order to reset the previous values
 //
 //  defer ReplaceArgs(t, "alpha")()
-func ReplaceArgs(t *testing.T, args ...string) func() {
+func ReplaceArgs(t test_helper.TInterface, args ...string) func() {
 	t.Helper()
 
 	previous := os.Args

--- a/internal/replace_console.go
+++ b/internal/replace_console.go
@@ -18,9 +18,9 @@ package internal
 
 import (
 	"fmt"
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"io/ioutil"
 	"os"
-	"testing"
 )
 
 // Console represents the standard console objects, stdin, stdout, and stderr.
@@ -34,7 +34,7 @@ type Console struct {
 }
 
 // Err returns a string representation of captured stderr.
-func (c Console) Err(t *testing.T) string {
+func (c Console) Err(t test_helper.TInterface) string {
 	t.Helper()
 
 	err := c.errWrite.Close()
@@ -51,7 +51,7 @@ func (c Console) Err(t *testing.T) string {
 }
 
 // In writes a string and closes the connection once complete.
-func (c Console) In(t *testing.T, string string) {
+func (c Console) In(t test_helper.TInterface, string string) {
 	t.Helper()
 
 	_, err := fmt.Fprint(c.inWrite, string)
@@ -66,7 +66,7 @@ func (c Console) In(t *testing.T, string string) {
 }
 
 // Out returns a string representation of captured stdout.
-func (c Console) Out(t *testing.T) string {
+func (c Console) Out(t test_helper.TInterface) string {
 	t.Helper()
 
 	err := c.outWrite.Close()
@@ -87,7 +87,7 @@ func (c Console) Out(t *testing.T) string {
 //
 // c, d := ReplaceConsole(t)
 // defer d()
-func ReplaceConsole(t *testing.T) (Console, func()) {
+func ReplaceConsole(t test_helper.TInterface) (Console, func()) {
 	t.Helper()
 
 	var console Console

--- a/internal/replace_working_directory.go
+++ b/internal/replace_working_directory.go
@@ -17,15 +17,15 @@
 package internal
 
 import (
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"os"
-	"testing"
 )
 
 // ReplaceWorkingDirectory replaces the current working directory (os.Getwd()) with a new value.  Returns a function for
 // use with defer in order to reset the previous value
 //
 // defer ReplaceWorkingDirectory(t, "alpha")()
-func ReplaceWorkingDirectory(t *testing.T, dir string) func() {
+func ReplaceWorkingDirectory(t test_helper.TInterface, dir string) func() {
 	t.Helper()
 
 	previous, err := os.Getwd()

--- a/test/copy_file.go
+++ b/test/copy_file.go
@@ -17,13 +17,13 @@
 package test
 
 import (
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"os"
-	"testing"
 )
 
 // CopyFile copies source to destination.  Before writing, it creates all required parent directories for the
 // destination.
-func CopyFile(t *testing.T, source string, destination string) {
+func CopyFile(t test_helper.TInterface, source string, destination string) {
 	t.Helper()
 
 	s, err := os.Open(source)

--- a/test/replace_env.go
+++ b/test/replace_env.go
@@ -17,15 +17,15 @@
 package test
 
 import (
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"os"
-	"testing"
 )
 
 // ReplaceEnv replaces an environment variable.  Returns a function for use with defer in order to reset the previous
 // value.
 //
 // defer ReplaceEnv(t, "alpha", "bravo")()
-func ReplaceEnv(t *testing.T, key string, value string) func() {
+func ReplaceEnv(t test_helper.TInterface, key string, value string) func() {
 	t.Helper()
 
 	previous, ok := os.LookupEnv(key)

--- a/test/scratch_dir.go
+++ b/test/scratch_dir.go
@@ -17,13 +17,13 @@
 package test
 
 import (
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"io/ioutil"
 	"path/filepath"
-	"testing"
 )
 
 // ScratchDir returns a safe scratch directory for tests to modify.
-func ScratchDir(t *testing.T, prefix string) string {
+func ScratchDir(t test_helper.TInterface, prefix string) string {
 	t.Helper()
 
 	tmp, err := ioutil.TempDir("", prefix)

--- a/test/test_build_factory.go
+++ b/test/test_build_factory.go
@@ -20,10 +20,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"os"
-	"path/filepath"
-	"testing"
-
 	"github.com/buildpack/libbuildpack/buildplan"
 	bpLayers "github.com/buildpack/libbuildpack/layers"
 	bpServices "github.com/buildpack/libbuildpack/services"
@@ -35,6 +31,9 @@ import (
 	"github.com/cloudfoundry/libcfbuildpack/layers"
 	"github.com/cloudfoundry/libcfbuildpack/logger"
 	"github.com/cloudfoundry/libcfbuildpack/services"
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
+	"os"
+	"path/filepath"
 )
 
 // BuildFactory is a factory for creating a test Build.
@@ -51,7 +50,7 @@ type BuildFactory struct {
 	// Runner is the used to capture commands executed outside the process.
 	Runner *Runner
 
-	t *testing.T
+	t test_helper.TInterface
 }
 
 // AddBuildPlan adds an entry to a build plan.
@@ -180,7 +179,7 @@ func (f *BuildFactory) newDependency(id string, version string, name string) bui
 }
 
 // NewBuildFactory creates a new instance of BuildFactory.
-func NewBuildFactory(t *testing.T) *BuildFactory {
+func NewBuildFactory(t test_helper.TInterface) *BuildFactory {
 	t.Helper()
 
 	root := ScratchDir(t, "build")

--- a/test/test_detect_factory.go
+++ b/test/test_detect_factory.go
@@ -17,15 +17,14 @@
 package test
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
-
 	"github.com/buildpack/libbuildpack/buildplan"
 	bp "github.com/buildpack/libbuildpack/services"
 	"github.com/buildpack/libbuildpack/stack"
 	"github.com/cloudfoundry/libcfbuildpack/detect"
 	"github.com/cloudfoundry/libcfbuildpack/services"
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
+	"os"
+	"path/filepath"
 )
 
 // DetectFactory is a factory for creating a test Detect.
@@ -42,7 +41,7 @@ type DetectFactory struct {
 	// Runner is the used to capture commands executed outside the process.
 	Runner *Runner
 
-	t *testing.T
+	t test_helper.TInterface
 }
 
 // AddBuildPlan adds an entry to a build plan.
@@ -68,7 +67,7 @@ func (f *DetectFactory) AddService(name string, credentials services.Credentials
 }
 
 // NewDetectFactory creates a new instance of DetectFactory.
-func NewDetectFactory(t *testing.T) *DetectFactory {
+func NewDetectFactory(t test_helper.TInterface) *DetectFactory {
 	t.Helper()
 
 	root := ScratchDir(t, "detect")

--- a/test/touch_file.go
+++ b/test/touch_file.go
@@ -17,14 +17,14 @@
 package test
 
 import (
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"testing"
 )
 
 // TouchFile writes a zero-length file during testing.
-func TouchFile(t *testing.T, elem ...string) {
+func TouchFile(t test_helper.TInterface, elem ...string) {
 	filename := filepath.Join(elem...)
 
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {

--- a/test/write_file.go
+++ b/test/write_file.go
@@ -16,12 +16,10 @@
 
 package test
 
-import (
-	"testing"
-)
+import "github.com/cloudfoundry/libcfbuildpack/test_helper"
 
 // WriteFile writes a file during testing.
-func WriteFile(t *testing.T, filename string, format string, args ...interface{}) {
+func WriteFile(t test_helper.TInterface, filename string, format string, args ...interface{}) {
 	t.Helper()
 
 	WriteFileWithPerm(t, filename, 0644, format, args...)

--- a/test/write_file_from_reader.go
+++ b/test/write_file_from_reader.go
@@ -17,15 +17,15 @@
 package test
 
 import (
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"io"
 	"os"
 	"path/filepath"
-	"testing"
 )
 
 // WriteFileFromReader writes a file with the given content from a io.Reader.  Before writing, it creates all required
 // parent directories for the file.
-func WriteFileFromReader(t *testing.T, filename string, perm os.FileMode, source io.Reader) {
+func WriteFileFromReader(t test_helper.TInterface, filename string, perm os.FileMode, source io.Reader) {
 	t.Helper()
 
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {

--- a/test/write_file_with_perm.go
+++ b/test/write_file_with_perm.go
@@ -18,14 +18,14 @@ package test
 
 import (
 	"fmt"
+	"github.com/cloudfoundry/libcfbuildpack/test_helper"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"testing"
 )
 
 // WriteFileWithPerm writes a file with specific permissions during testing.
-func WriteFileWithPerm(t *testing.T, filename string, perm os.FileMode, format string, args ...interface{}) {
+func WriteFileWithPerm(t test_helper.TInterface, filename string, perm os.FileMode, format string, args ...interface{}) {
 	t.Helper()
 
 	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {

--- a/test_helper/test_helper.go
+++ b/test_helper/test_helper.go
@@ -1,0 +1,6 @@
+package test_helper
+
+type TInterface interface {
+	Fatal(args ...interface{})
+	Helper()
+}


### PR DESCRIPTION
This allows the library to be used with other testing frameworks e.g
Ginkgo that doesn't provide access to `*testing.T`