### PR TITLE
Check to ensure a layer contributor creates a layer directory

### DIFF
--- a/layers/layer.go
+++ b/layers/layer.go
@@ -17,9 +17,11 @@
 package layers
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/buildpack/libbuildpack/layers"
+	"github.com/cloudfoundry/libcfbuildpack/helper"
 	"github.com/cloudfoundry/libcfbuildpack/logger"
 	"github.com/fatih/color"
 )
@@ -129,6 +131,13 @@ func (l Layer) Contribute(expected logger.Identifiable, contributor LayerContrib
 	if err := contributor(l); err != nil {
 		l.Logger.Debug("Error during contribution")
 		return err
+	}
+
+	if exists, err := helper.FileExists(l.Root); err != nil {
+		return err
+	} else if !exists {
+		name, _ := expected.Identity()
+		return fmt.Errorf("expected %s layer contribution", name)
 	}
 
 	return l.WriteMetadata(expected, flags...)

--- a/layers/layer_test.go
+++ b/layers/layer_test.go
@@ -98,6 +98,7 @@ Bravo = 1
 
 			g.Expect(layer.Contribute(metadata{"test-value", 1}, func(layer layers.Layer) error {
 				contributed = true
+				test.TouchFile(t, layer.Root, "test-file")
 				return nil
 			})).To(Succeed())
 
@@ -113,6 +114,13 @@ Bravo = 1
 
 			g.Expect(filepath.Join(layer.Root, "test-file")).To(BeARegularFile())
 		})
+
+		it("returns an error if the contributor does not populate the layer", func() {
+			g.Expect(layer.Contribute(metadata{"test-value", 1}, func(layer layers.Layer) error {
+				return nil
+			})).To(MatchError("expected test-value layer contribution"))
+		})
+
 	}, spec.Report(report.Terminal{}))
 }
 


### PR DESCRIPTION
If a layer directory is not contributed but, layer metadata is written
the lifecycle will attempt to unsuccessfully reuse the layer from a
previous image.

This leads to an opaque error when the exporter fails:
```
===> EXPORTING
[exporter] Error: failed to export: cannot reuse 'org.cloudfoundry.dep-cnb:app-binary', previous image has no metadata for layer 'org.cloudfoundry.dep-cnb:app-binary'
```

The buildpack should error when unsuccessfully contributing the layer. 